### PR TITLE
Changed content_type check to include instead of equals

### DIFF
--- a/lib/mail_auto_link_obfuscation/auto_link_obfuscator.rb
+++ b/lib/mail_auto_link_obfuscation/auto_link_obfuscator.rb
@@ -15,8 +15,8 @@ module MailAutoLinkObfuscation
 
     def run
       extract_link_whitelist_from_html
-      transform_html_body if @mail.content_type == 'text/html'
-      transform_text_body if @mail.content_type == 'text/plain'
+      transform_html_body if @mail.content_type.include? 'text/html'
+      transform_text_body if @mail.content_type.include? 'text/plain'
       transform_html_part if @mail.html_part
       transform_text_part if @mail.text_part
       @mail
@@ -34,7 +34,7 @@ module MailAutoLinkObfuscation
     end
 
     def html_body_doc
-      return unless @mail.content_type == 'text/html'
+      return unless @mail.content_type.include? 'text/html'
       @html_body_doc ||= Nokogiri::HTML(@mail.body.decoded)
     end
 

--- a/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
+++ b/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe MailAutoLinkObfuscation::AutoLinkObfuscator do
 
   context 'when mail has text body' do
     let(:mail) do
-      Mail.new(body: content, content_type: 'text/plain')
+      Mail.new(body: content, content_type: 'text/plain; charset=UTF-8')
     end
 
     it 'obfuscates linkables' do
@@ -63,7 +63,7 @@ RSpec.describe MailAutoLinkObfuscation::AutoLinkObfuscator do
 
   context 'when mail has html body' do
     let(:mail) do
-      Mail.new(body: content, content_type: 'text/html')
+      Mail.new(body: content, content_type: 'text/html; charset=UTF-8')
     end
 
     it 'obfuscates linkables' do


### PR DESCRIPTION
`mail.content_type` can contain more than only `'text/html'` eg . `'text/html; charset=UTF-8'`. 
Changed `mail.content_type` check to include, instead of equals in order to make the content_type in the example valid as well.