### PR TITLE
Fix matching

### DIFF
--- a/lib/mail_auto_link_obfuscation/auto_link_obfuscator.rb
+++ b/lib/mail_auto_link_obfuscation/auto_link_obfuscator.rb
@@ -79,7 +79,7 @@ module MailAutoLinkObfuscation
 
     def transform_auto_linked_pattern(text)
       text.gsub(AUTO_LINKED_PATTERN) do |match|
-        @link_whitelist.include?(match) ? match : yield(match)
+        @link_whitelist.any? { |whitelisted_link| match.start_with?(whitelisted_link) } ? match : yield(match)
       end
     end
   end

--- a/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
+++ b/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
@@ -330,4 +330,23 @@ RSpec.describe MailAutoLinkObfuscation::AutoLinkObfuscator do
       expect(text_part).not_to include('hacker.com')
     end
   end
+
+  context 'matches URLs when the URL is followed by a dot' do
+    let(:mail) do
+      Mail.new.tap do |mail|
+        mail.text_part = 'Natuurlijk vinden we het ook prima als je deze e-mails niet wil ontvangen. Afmelden kan via https://moneybird.com/user/edit.'
+        mail.html_part = '<p>Natuurlijk vinden we het ook prima als je deze e-mails <a href="https://moneybird.com/user/edit">niet wil ontvangen</a>.</p>'
+      end
+    end
+
+    it 'does not change links in html part when used in anchor' do
+      obfuscator.run
+      expect(html_part).to include('https://moneybird.com/user/edit')
+    end
+
+    it 'does not change links in text part when used in anchor in html part' do
+      obfuscator.run
+      expect(text_part).to include('https://moneybird.com/user/edit')
+    end
+  end
 end

--- a/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
+++ b/spec/lib/mail_auto_link_obfuscation/auto_link_obfuscator_spec.rb
@@ -334,8 +334,8 @@ RSpec.describe MailAutoLinkObfuscation::AutoLinkObfuscator do
   context 'matches URLs when the URL is followed by a dot' do
     let(:mail) do
       Mail.new.tap do |mail|
-        mail.text_part = 'Natuurlijk vinden we het ook prima als je deze e-mails niet wil ontvangen. Afmelden kan via https://moneybird.com/user/edit.'
-        mail.html_part = '<p>Natuurlijk vinden we het ook prima als je deze e-mails <a href="https://moneybird.com/user/edit">niet wil ontvangen</a>.</p>'
+        mail.text_part = 'See link: https://moneybird.com/user/edit.'
+        mail.html_part = '<p>See <a href="https://moneybird.com/user/edit">link</a>.</p>'
       end
     end
 


### PR DESCRIPTION
When an URL is followed by a `.` in the plain text part, the whitelist does not match. Therefore the URL gets obfuscated by accident. By only looking at the prefix we can prevent this behaviour and still have a secure way to obfuscate all unwanted situations.