### PR TITLE
Security advisory dependency bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     nenv (0.3.0)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -160,7 +160,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -297,4 +297,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.9
+  4.0.11


### PR DESCRIPTION
Bumps net-imap and nokogiri (moneybird/security-advisory-monitor#5380, moneybird/security-advisory-monitor#5479)